### PR TITLE
Fix/keyboard issue

### DIFF
--- a/KAPinField.podspec
+++ b/KAPinField.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/kirualex/KAPinField'
   s.license          = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Alexis Creuzot" => "alexis.creuzot@gmail.com" }
-  s.source           = { :git => "https://github.com/aabanaag/KAPinField.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/kirualex/KAPinField.git", :tag => s.version.to_s }
   s.platform         = :ios, '9.0'
   s.source_files     = '**/KAPinField.swift'
 end

--- a/KAPinField.podspec
+++ b/KAPinField.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KAPinField'
-  s.version          =  '5.0.0'
+  s.version          =  '5.0.1'
   s.summary          = 'Lightweight, highly customizable Pin Code Field library for iOS, written in Swift'
   s.homepage         = 'https://github.com/kirualex/KAPinField'
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/KAPinField/Example/ViewController.swift
+++ b/KAPinField/Example/ViewController.swift
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
         self.refreshPinField()
         
         // Get focus
-        _ = pinField.becomeFirstResponder()
+        pinField.becomeFirstResponder()
     }
 
     

--- a/KAPinField/Sources/KAPinField.swift
+++ b/KAPinField/Sources/KAPinField.swift
@@ -63,6 +63,7 @@ public struct KAPinFieldAppearance {
     public var backActiveColor : UIColor?
     public var backBorderActiveColor : UIColor?
     public var backRounded : Bool = false
+    public var keyboardType: UIKeyboardType = .numberPad
 }
 
 // Mark: - KAPinField Class
@@ -100,10 +101,9 @@ public class KAPinField : UITextField {
     
     // Uses an invisible UITextField to handle text
     // this is necessary for iOS12 .oneTimePassword feature
-    private var invisibleField :UITextField = {
+    // Remove textField.inputView = UIView() to fix issue with keyboard
+    private var invisibleField: UITextField = {
         let textField = UITextField()
-        textField.inputView = UIView()
-        textField.inputAccessoryView = nil
         return textField
     }()
     private var invisibleText : String {
@@ -214,7 +214,7 @@ public class KAPinField : UITextField {
     
     // Mark: - Public functions
     
-    override public func becomeFirstResponder() -> Bool {
+    @discardableResult override public func becomeFirstResponder() -> Bool {
         return self.invisibleField.becomeFirstResponder()
     }
     
@@ -331,12 +331,15 @@ public class KAPinField : UITextField {
         self.invisibleField.autocapitalizationType = .none
         self.invisibleField.autocorrectionType = .no
         self.invisibleField.spellCheckingType = .no
+
+        self.invisibleField.keyboardType = self.appearance.keyboardType
         
         if #available(iOS 12.0, *) {
             // Show possible prediction on iOS >= 12
             self.invisibleField.textContentType = .oneTimeCode
             self.invisibleField.autocorrectionType = .yes
         }
+
         self.addSubview(self.invisibleField)
         self.invisibleField.addTarget(self, action: #selector(reloadAppearance), for: .allEditingEvents)
         

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pinField.properties.text = "123" // You can set part or all of the text
 pinField.properties.animateFocus = true // Animate the currently focused token
 pinField.properties.isSecure = false // Secure pinField will hide actual input
 pinField.properties.secureToken = "*" // Token used to hide actual character input when using isSecure = true
+pinField.properties.isUppercased = false // You can set this to convert input to uppercased.
 ```
 
 ##### Styling
@@ -92,6 +93,7 @@ pinField.appearance.backFocusColor = UIColor.clear
 pinField.appearance.backBorderFocusColor = UIColor.white.withAlphaComponent(0.8)
 pinField.appearance.backActiveColor = UIColor.clear
 pinField.appearance.backBorderActiveColor = UIColor.white
+pinField.appearance.keyboardType = UIKeyboardType.numberPad // Specify keyboard type
 ```
 
 ### Font


### PR DESCRIPTION
# Proposed Changes

- removed `textField.inputView = UIView()`, this was causing an issue where the keyboard is not showing only the numberPad toolbar
- added `@discardableResult` to becomeFirstResponse override
- added keyboardType to appearance to specify the keyboard type
- bump version for podspec